### PR TITLE
Update default.json5

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -12,12 +12,12 @@
   // Extensions of file matches of type yaml
   // This makes renovate scan the same yaml file multiple times but since theres no naming convensions this is necessary
   "docker-compose": {
-      "fileMatch": ["\.yaml$"]
+      "fileMatch": [".\ya?ml$"]
   },
   "github-actions": {
     "fileMatch": [".\ya?ml$"]
   },
-  "helm": {
+  "kubernetes": {
     "fileMatch": [".\ya?ml$"]
   },
   "updateNotScheduled": false,


### PR DESCRIPTION
update filematches for kubernetes
remove helm filematches (subcategory of k8s)
update docker-compose filematch

all now includes optional a? so that it scans both .yaml & .yml files